### PR TITLE
Fix indentation error

### DIFF
--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -30,7 +30,7 @@ def start(args, session, unlocked_cb=None):
 
         hide = False
         # FuriOS: don't add an icon for default apps such as documents, settings or microG
-         if packageName == "com.android.documentsui" or packageName == "com.android.inputmethod.latin" \
+        if packageName == "com.android.documentsui" or packageName == "com.android.inputmethod.latin" \
              or packageName == "com.android.settings" or packageName == "com.google.android.gms" \
              or packageName == "org.lineageos.jelly" or packageName == "org.lineageos.aperture" \
              or packageName == "com.android.messaging" or packageName == "com.android.dialer":

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -30,9 +30,11 @@ def start(args, session, unlocked_cb=None):
 
         hide = False
         # FuriOS: don't add an icon for default apps such as documents, settings or microG
-        if packageName == "com.android.documentsui" or packageName == "com.android.inputmethod.latin" \
-            or packageName == "com.android.settings" or packageName == "com.google.android.gms":
-            hide = True
+         if packageName == "com.android.documentsui" or packageName == "com.android.inputmethod.latin" \
+             or packageName == "com.android.settings" or packageName == "com.google.android.gms" \
+             or packageName == "org.lineageos.jelly" or packageName == "org.lineageos.aperture" \
+             or packageName == "com.android.messaging" or packageName == "com.android.dialer":
+             hide = True
 
         desktop_file_path = apps_dir + "/waydroid." + packageName + ".desktop"
         if not os.path.exists(desktop_file_path):


### PR DESCRIPTION
There's an errant space/indent in line 33 which halted waydroid updates with an unexpected indent error

```
Sorry: IndentationError: unexpected indent (user_manager.py, line 33)dpkg: error processing package waydroid (--configure):
 installed waydroid package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 waydroid
```