### PR TITLE
Pass actual android notifications to Linux

### DIFF
--- a/tools/actions/notification_client.py
+++ b/tools/actions/notification_client.py
@@ -13,98 +13,170 @@ from tools.interfaces import IPlatform
 from tools.actions import app_manager
 
 main_loop = None
-
-pkg_name = ""
-app_notifications = {}
+open_notifications = {}
+action_handlers = {}
 
 def stop_main_loop():
-    global main_loop
     if main_loop:
         main_loop.quit()
 
     return False
 
-def on_action_invoked(notification, action_key):
-    args = None
-    global pkg_name
-    if action_key == 'open':
-        args = helpers.arguments()
-        args.cache = {}
-        args.work = config.defaults["work"]
-        args.config = args.work + "/waydroid.cfg"
-        args.log = args.work + "/waydroid.log"
-        args.sudo_timer = True
-        args.timeout = 1800
-        args.PACKAGE = f"{pkg_name}"
-        app_manager.launch(args)
+def get_app_name(package_name):
+    args = helpers.arguments()
+    args.cache = {}
+    args.work = config.defaults["work"]
+    args.config = args.work + "/waydroid.cfg"
+    args.log = args.work + "/waydroid.log"
+    args.sudo_timer = True
+    args.timeout = 1800
 
-def on_new_message(package_name, count):
-    # logging.info(f"Received new message notification: packagename = {package_name}, count = {count}")
+    ipc.DBusSessionService()
+    cm = ipc.DBusContainerService()
+    session = cm.GetSession()
+    if session["state"] == "FROZEN":
+        cm.Unfreeze()
 
-    global pkg_name
-    args = None
-    app_name_dict = {}
-    try:
-        args = helpers.arguments()
-        args.cache = {}
-        args.work = config.defaults["work"]
-        args.config = args.work + "/waydroid.cfg"
-        args.log = args.work + "/waydroid.log"
-        args.sudo_timer = True
-        args.timeout = 1800
+    platform_service = IPlatform.get_service(args)
+    if platform_service:
+        apps_list = platform_service.getAppsInfo()
+        app_name_dict = {app['packageName']: app['name'] for app in apps_list}
+        app_name = app_name_dict.get(package_name)
+        return True, app_name
 
-        ipc.DBusSessionService()
-        cm = ipc.DBusContainerService()
-        session = cm.GetSession()
-        if session["state"] == "FROZEN":
-            cm.Unfreeze()
+    logging.error("Failed to access IPlatform service")
 
-        platformService = IPlatform.get_service(args)
-        if platformService:
-            appsList = platformService.getAppsInfo()
-            app_name_dict = {app['packageName']: app['name'] for app in appsList}
-            app_name = app_name_dict.get(package_name)
-            pkg_name = package_name
-            notify_send(app_name, count)
-        else:
-            logging.error("Failed to access IPlatform service")
+    if session["state"] == "FROZEN":
+        cm.Freeze()
 
-        if session["state"] == "FROZEN":
-            cm.Freeze()
+    return False, None
 
-    except dbus.DBusException:
-        logging.error("WayDroid session is stopped")
+### Notification click actions ###
 
-def notify_send(app_name, count):
-    global main_loop
+def on_action_invoked(notification_id, action_key):
+    if notification_id in action_handlers:
+        handler = action_handlers[notification_id]
+        handler(action_key)
+        del action_handlers[notification_id]
+
+def create_action_handler(pkg_name):
+    def handler(action_key):
+        if action_key == 'open':
+            args = helpers.arguments()
+            args.cache = {}
+            args.work = config.defaults["work"]
+            args.config = args.work + "/waydroid.cfg"
+            args.log = args.work + "/waydroid.log"
+            args.sudo_timer = True
+            args.timeout = 1800
+            args.PACKAGE = pkg_name
+            app_manager.launch(args)
+    return handler
+
+### Calls to freedesktop notification API ###
+
+def notify_send(app_name, package_name, ticker, title, text, _is_foreground_service,
+                show_light, updates_id):
+    notification_id = 0
+
+    # When the title and text fields are not present, we choose an empty title
+    # and the ticker as text.
+    if title == '' or text == '':
+        title = ''
+        text = ticker
 
     bus = dbus.SessionBus()
-    notification_service = bus.get_object('org.freedesktop.Notifications', '/org/freedesktop/Notifications')
-    notifications = dbus.Interface(notification_service, dbus_interface='org.freedesktop.Notifications')
+    notification_service = bus.get_object('org.freedesktop.Notifications',
+                                          '/org/freedesktop/Notifications')
+    notifications = dbus.Interface(notification_service,
+                                   dbus_interface='org.freedesktop.Notifications')
     notifications.connect_to_signal("ActionInvoked", on_action_invoked)
 
-    if app_name in app_notifications:
-        notif_id = app_notifications[app_name]['id']
-        notifications.CloseNotification(notif_id)
-
-    new_notif_id = notifications.Notify(
+    notification_id = notifications.Notify(
         app_name,
-        0,
-        "/usr/share/icons/hicolor/512x512/apps/waydroid.png",
-        f"{app_name}",
-        f"You have {count} notification(s)",
+        updates_id,
+        config.session_defaults["waydroid_data"] + "/icons/"
+        + package_name + ".png",
+        title,
+        text,
         ['default', 'Open', 'open', 'Open'],
-        {'urgency': 1},
+        {'urgency': 1 if show_light else 0},
         5000
     )
 
-    app_notifications[app_name] = {'id': new_notif_id, 'count': count}
+    action_handlers[int(notification_id)] = create_action_handler(package_name)
+    return notification_id
+
+def close_notification_send(notification_id):
+    bus = dbus.SessionBus()
+    notification_service = bus.get_object('org.freedesktop.Notifications',
+                                          '/org/freedesktop/Notifications')
+    notifications = dbus.Interface(notification_service,
+                                   dbus_interface='org.freedesktop.Notifications')
+
+    notifications.CloseNotification(notification_id)
+
+    if notification_id in action_handlers:
+        del action_handlers[notification_id]
+
+### Helper functions ###
+
+def try_and_loop(f):
+    global main_loop
+
+    try:
+        f()
+    except dbus.DBusException:
+        logging.error("WayDroid session is stopped")
 
     GLib.timeout_add_seconds(3, stop_main_loop)
     main_loop = GLib.MainLoop()
     main_loop.run()
 
-def start(args):
+
+### Callbacks for subscribed notification server signals ###
+
+def on_new_message(msg_hash, _msg_id, package_name, ticker, title, text, is_foreground_service,
+                   is_group_summary, show_light, _when):
+    #logging.info(f"Received new message notification: {msg_hash}, {_msg_id}, {package_name}, " +
+    #             f"{ticker}, {title}, {text}, {is_foreground_service}, {is_group_summary}, " +
+    #             f"{show_light}, {_when}")
+    def fun():
+        ok, app_name = get_app_name(package_name)
+        if ok and not is_group_summary:
+            notification_id = notify_send(app_name, package_name, ticker, title, text,
+                                          is_foreground_service, show_light, 0)
+            open_notifications[msg_hash] = notification_id
+
+    try_and_loop(fun)
+
+def on_update_message(msg_hash, replaces_hash, _msg_id, package_name, ticker, title, text,
+                      is_foreground_service, _is_group_summary, show_light, _when):
+    #logging.info(f"Received update message notification: {msg_hash}, {replaces_hash}, " +
+    #             f"{_msg_id}, {package_name}, {ticker}, {title}, {text}, " +
+    #             f"{is_foreground_service}, {_is_group_summary}, {show_light}, {_when}")
+    def fun():
+        ok, app_name = get_app_name(package_name)
+        if ok and replaces_hash in open_notifications:
+            notification_id = notify_send(app_name, package_name, ticker, title, text,
+                                          is_foreground_service, show_light,
+                                          open_notifications[replaces_hash])
+            open_notifications[msg_hash] = notification_id
+            del open_notifications[replaces_hash]
+
+    try_and_loop(fun)
+
+# on android, a notification disappeared (and was not replaced by another)
+def on_delete_message(msg_hash):
+    #logging.info(f"Received delete message notification: {msg_hash}")
+    def fun():
+        if msg_hash in open_notifications:
+            close_notification_send(open_notifications[msg_hash])
+            del open_notifications[msg_hash]
+
+    try_and_loop(fun)
+
+def start(_args):
     global main_loop
     if main_loop is not None:
         logging.info("Notification client is already running.")
@@ -122,11 +194,25 @@ def start(args):
         bus_name='id.waydro.Notification',
         path='/id/waydro/Notification'
     )
+    system_bus.add_signal_receiver(
+        on_update_message,
+        signal_name="UpdateMessage",
+        dbus_interface='id.waydro.Notification',
+        bus_name='id.waydro.Notification',
+        path='/id/waydro/Notification'
+    )
+    system_bus.add_signal_receiver(
+        on_delete_message,
+        signal_name="DeleteMessage",
+        dbus_interface='id.waydro.Notification',
+        bus_name='id.waydro.Notification',
+        path='/id/waydro/Notification'
+    )
 
     main_loop = GLib.MainLoop()
     main_loop.run()
 
-def stop(args):
+def stop(_args):
     global main_loop
     if main_loop is None:
         logging.info("Notification client service is not running.")

--- a/tools/actions/notification_server.py
+++ b/tools/actions/notification_server.py
@@ -2,14 +2,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
-import sys
 import time
 import logging
 import threading
 import subprocess
 import dbus
 import dbus.service
-from collections import defaultdict
 
 running = False
 loop_thread = None
@@ -18,42 +16,56 @@ class INotification(dbus.service.Object):
     def __init__(self, bus_name, object_path='/id/waydro/Notification'):
         dbus.service.Object.__init__(self, bus_name, object_path)
 
-    @dbus.service.signal(dbus_interface='id.waydro.Notification', signature='si')
-    def NewMessage(self, package_name, count):
+    @dbus.service.signal(dbus_interface='id.waydro.Notification', signature='ssssssbbbt')
+    def NewMessage(self, msg_hash, msg_id, package_name, ticker, title, text, is_foreground_service,
+                   is_group_summary, show_light, when):
         pass
 
-def get_notifications(old_notification):
-    global running
-    notification_count = defaultdict(int)
+    @dbus.service.signal(dbus_interface='id.waydro.Notification', signature='sssssssbbbt')
+    def UpdateMessage(self, msg_hash, replaces_hash, msg_id, package_name, ticker, title, text,
+                      is_foreground_service, is_group_summary, show_light, when):
+        pass
+
+    @dbus.service.signal(dbus_interface='id.waydro.Notification', signature='s')
+    def DeleteMessage(self, msg_hash):
+        pass
+
+def get_notifications(_old_notification):
+    notifications = {}
+    old_notifications = {}
 
     system_bus = dbus.SystemBus()
     bus_name = dbus.service.BusName('id.waydro.Notification', system_bus)
     interface = INotification(bus_name, object_path='/id/waydro/Notification')
 
     notification_command = [
-        "lxc-attach", "-P", "/var/lib/waydroid/lxc",
-        "-n", "waydroid", "--clear-env", "--", "/system/bin/sh", "-c", "dumpsys notification"
+        "lxc-attach", "-P", "/var/lib/waydroid/lxc", "-n", "waydroid", "--clear-env", "--",
+        "/system/bin/sh", "-c", "dumpsys notification --noredact"
     ]
 
     applist_command = [
-        "lxc-attach", "-P", "/var/lib/waydroid/lxc",
-        "-n", "waydroid", "--clear-env", "--", "/system/bin/sh", "-c", "pm list packages -3"
+        "lxc-attach", "-P", "/var/lib/waydroid/lxc", "-n", "waydroid", "--clear-env", "--",
+        "/system/bin/sh", "-c", "pm list packages -3"
     ]
 
     logging.info("Starting notification server service")
 
     while running:
-        notification_process = subprocess.Popen(notification_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        notification_process = subprocess.Popen(notification_command, stdout=subprocess.PIPE,
+                                                stderr=subprocess.PIPE)
         notification_stdout, notification_stderr = notification_process.communicate()
 
         if notification_stderr:
+            for line in notification_stderr.splitlines():
+                logging.error(line)
+
             time.sleep(3)
             continue
 
         notification_stdout = notification_stdout.decode()
-        notification_filtered_output = re.findall(r"NotificationRecord.*", notification_stdout)
 
-        applist_process = subprocess.Popen(applist_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        applist_process = subprocess.Popen(applist_command, stdout=subprocess.PIPE,
+                                           stderr=subprocess.PIPE)
         applist_stdout, applist_stderr = applist_process.communicate()
 
         if applist_stderr:
@@ -63,26 +75,121 @@ def get_notifications(old_notification):
         applist_stdout = applist_stdout.decode()
         packages = [line.split(':')[1] for line in applist_stdout.splitlines() if ':' in line]
 
-        for line in notification_filtered_output:
-            fields = line.split("|")
+        # parse notifications
+        current_msg_hash = None
+        multiline_ticker = None
+        multiline_text = None
+        for line in notification_stdout.splitlines():
+            # ticker and text may be multi line and there seems no better way
+            # to parse this with the dumpsys format
+            if multiline_ticker:
+                if line.startswith("  "):
+                    notifications[current_msg_hash]['ticker'] = multiline_ticker
+                    multiline_ticker = None
+                else:
+                    multiline_ticker = multiline_ticker + "\n" + line
+                    continue
+            elif multiline_text:
+                if line.startswith("  "):
+                    notifications[current_msg_hash]['text'] = multiline_text[:-1]
+                    multiline_text = None
+                else:
+                    multiline_text = multiline_text + "\n" + line
+                    continue
 
-            if len(fields) > 1:
-                notification_name = fields[1].strip()
-                if notification_name in packages:
-                    notification_count[notification_name] += 1
+            if "NotificationRecord" in line:
+                current_msg_hash = None
+                fields = line.split("|")
+                if len(fields) > 3:
+                    package_name = fields[1].strip()
+                    res = re.search(r'NotificationRecord\(([^:]+):', line)
+                    if package_name in packages and res:
+                        current_msg_hash = res.group(1)
+                        notifications[current_msg_hash] = {
+                            'package_name': package_name,
+                            'msg_id': fields[2],
+                            'ticker': '',
+                            'title': '',
+                            'text': '',
+                            'is_foreground_msg': False,
+                            'is_group_summary': False,
+                            'show_light': False,
+                            'when': 0
+                        }
+            elif current_msg_hash:
+                msg_hash = current_msg_hash
 
-        for package_name, count in notification_count.items():
-            old_count = old_notification.get(package_name, 0)
+                if "  tickerText=" in line:
+                    multiline_ticker = line.replace('tickerText=','').strip()
+                elif "  android.title=" in line:
+                    res = re.search(r'android.title=\w+\s*\((.*)\)$', line)
+                    if res:
+                        notifications[msg_hash]['title'] = res.group(1).strip()
+                elif "  android.text=" in line:
+                    res = re.search(r'android.text=\w+\s*\((.*)$', line)
+                    if res:
+                        multiline_text = res.group(1).strip()
+                elif "  flags=" in line:
+                    flags = int(line.replace('flags=','').strip(), 0)
+                    notifications[msg_hash]['is_foreground_msg'] = \
+                      (flags & 0x00000040) != 0
+                    notifications[msg_hash]['is_group_summary'] = \
+                      (flags & 0x00000200) != 0
+                elif "  mLight=" in line:
+                    notifications[msg_hash]['show_light'] = \
+                      line.replace('mLight=','').strip() != "null"
+                elif "  when=" in line:
+                    notifications[msg_hash]['when'] = \
+                      int(line.replace('when=','').strip(), 0)
 
-            if count > old_count:
-                # logging.info(f"You have {count} notifications from {package_name}")
-                interface.NewMessage(package_name, count)
+        # analyse and send notifications
+        updated_hashes = set()
+        for msg_hash, n in notifications.items():
+            # this happens e.g. for foreground applications when they start.
+            # currently they are ignored, but they could also be transformed
+            # into a "<app> started in background" message
+            if (n['ticker'] == 'null' or n['ticker'] == '') and (n['title'] == '' or n['text'] == ''):
+                logging.error("Ticker is null and title or text are empty. skipping")
+                continue
 
-        old_notification = notification_count.copy()
-        notification_count = defaultdict(int)
+            # check if notification is new or an update (= message hash did not exist before)
+            if msg_hash not in old_notifications:
+                # search for msg_id in old notifications to see if this is an update
+                is_update_of = [h for h, o in old_notifications.items()
+                                if o['msg_id'] == n['msg_id']]
+                if is_update_of:
+                    #logging.info("Update Message (%s):", msg_hash)
+                    #logging.info(n)
+
+                    if len(is_update_of) > 1:
+                        logging.warning("Warning: Multiple messages w same msg_id at the same time")
+
+                    # send update
+                    updated_hashes.add(is_update_of[0])
+                    interface.UpdateMessage(msg_hash, is_update_of[0], n['msg_id'],
+                                            n['package_name'], n['ticker'], n['title'], n['text'],
+                                            n['is_foreground_msg'], n['is_group_summary'],
+                                            n['show_light'], n['when'])
+                else:
+                    #logging.info("New Message (%s):", msg_hash)
+                    #logging.info(n)
+
+                    # send new message
+                    interface.NewMessage(msg_hash, n['msg_id'], n['package_name'], n['ticker'],
+                                         n['title'], n['text'], n['is_foreground_msg'],
+                                         n['is_group_summary'], n['show_light'], n['when'])
+
+        # send removal messages
+        for msg_hash in old_notifications:
+            if msg_hash not in notifications and msg_hash not in updated_hashes:
+                #logging.info(f"Send removal message: {msg_hash}")
+                interface.DeleteMessage(msg_hash)
+
+        old_notifications = notifications
+        notifications = {}
         time.sleep(3)
 
-def start(args):
+def start(_args):
     global running
     global loop_thread
 
@@ -90,9 +197,8 @@ def start(args):
     loop_thread = threading.Thread(target=get_notifications, args=({},))
     loop_thread.start()
 
-def stop(args):
+def stop(_args):
     global running
-    global loop_thread
 
     running = False
     if loop_thread is not None:


### PR DESCRIPTION
notifications_server:
- parse more details about the notifications from the dump, e.g. message hash, title + text (instead of just ticker) and interesting flags
- differentiate between new notification and notification updates
- send removal messages when android notifications disappear (e.g. when messenger messages are read in the android app)

notification_client:
- add notification update and notification removal
- only use urgency 1 when android notification would have triggered the notification led ("show_light"), otherwise 0
- ignore android group banner and background service started notifications for now