### PR TITLE
android-store: Use msgspec for loads

### DIFF
--- a/android-store/android-store.py
+++ b/android-store/android-store.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (C) 2025 Bardia Moshiri <bardia@furilabs.com>
+# Copyright (C) 2025 Luis Garcia <git@luigi311.com>
 
 from argparse import ArgumentParser
 from inspect import currentframe

--- a/android-store/android-store.py
+++ b/android-store/android-store.py
@@ -10,6 +10,7 @@ import asyncio
 import aiohttp
 import functools
 import json
+import msgspec
 import sys
 import os
 
@@ -316,8 +317,8 @@ class FDroidInterface(ServiceInterface):
                     if not repo_url:
                         continue
 
-                    with open(index_path, 'r') as f:
-                        index_data = json.load(f)
+                    with open(index_path, 'rb') as f:
+                        index_data = msgspec.json.decode(f.read())
 
                     for package_id, package_data in index_data['packages'].items():
                         name = self.get_localized_text(package_data['metadata'].get('name', ''))
@@ -461,8 +462,8 @@ class FDroidInterface(ServiceInterface):
                     if not repo_url:
                         continue
 
-                    with open(index_path, 'r') as f:
-                        index_data = json.load(f)
+                    with open(index_path, 'rb') as f:
+                        index_data = msgspec.json.decode(f.read())
 
                     if package_id in index_data['packages']:
                         package_data = index_data['packages'][package_id]
@@ -594,8 +595,8 @@ class FDroidInterface(ServiceInterface):
                     if not repo_url:
                         continue
 
-                    with open(index_path, 'r') as f:
-                        index_data = json.load(f)
+                    with open(index_path, 'rb') as f:
+                        index_data = msgspec.json.decode(f.read())
 
                     if package_name in index_data['packages']:
                         package_data = index_data['packages'][package_name]

--- a/debian/control
+++ b/debian/control
@@ -37,5 +37,6 @@ Depends: ${misc:Depends},
          ${python3:Depends},
          waydroid,
          python3-dbus-fast,
+         python3-msgspec,
 Description: Android software store bridge
  This bridge allows to install Android apps from software stores through DBus


### PR DESCRIPTION
pythons default json is slow at loading compared to msgspec. This also brings down memory consumption